### PR TITLE
Change and use the fully qualified module name

### DIFF
--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"failsafe"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // ErrCircuitBreakerOpen is returned when an execution is attempted against a circuit breaker that is open.

--- a/circuitbreaker/circuitbreakerbuilder.go
+++ b/circuitbreaker/circuitbreakerbuilder.go
@@ -3,9 +3,9 @@ package circuitbreaker
 import (
 	"time"
 
-	"failsafe"
-	"failsafe/internal/util"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/util"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 /*

--- a/circuitbreaker/circuitbreakerexecutor.go
+++ b/circuitbreaker/circuitbreakerexecutor.go
@@ -1,9 +1,9 @@
 package circuitbreaker
 
 import (
-	"failsafe"
-	"failsafe/internal"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // circuitBreakerExecutor is a failsafe.PolicyExecutor that handles failures according to a CircuitBreaker.

--- a/circuitbreaker/circuitstates.go
+++ b/circuitbreaker/circuitstates.go
@@ -3,8 +3,8 @@ package circuitbreaker
 import (
 	"time"
 
-	"failsafe"
-	"failsafe/internal/util"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/util"
 )
 
 // State of a CircuitBreaker.

--- a/circuitbreaker/circuitstats.go
+++ b/circuitbreaker/circuitstats.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/bits-and-blooms/bitset"
 
-	"failsafe/internal/util"
+	"github.com/failsafe-go/failsafe-go/internal/util"
 )
 
 // stats for a CircuitBreaker.

--- a/circuitbreaker/circuitstats_test.go
+++ b/circuitbreaker/circuitstats_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 var _ circuitStats = &countingCircuitStats{}

--- a/circuitbreaker/openstate_test.go
+++ b/circuitbreaker/openstate_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
+	"github.com/failsafe-go/failsafe-go"
 )
 
 var _ circuitState[any] = &openState[any]{}

--- a/executor_test.go
+++ b/executor_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/fallback"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 func TestGetWithSuccess(t *testing.T) {

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -1,8 +1,8 @@
 package fallback
 
 import (
-	"failsafe"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // Fallback is a Policy that handles failures using a fallback function, result, or error.

--- a/fallback/fallbackexecutor.go
+++ b/fallback/fallbackexecutor.go
@@ -1,9 +1,9 @@
 package fallback
 
 import (
-	"failsafe"
-	"failsafe/internal"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // fallbackExecutor is a failsafe.PolicyExecutor that handles failures according to a Fallback.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module failsafe
+module github.com/failsafe-go/failsafe-go
 
 go 1.20
 

--- a/internal/execution.go
+++ b/internal/execution.go
@@ -1,6 +1,6 @@
 package internal
 
-import failsafe "github.com/failsafe-go/failsafe-go"
+import "github.com/failsafe-go/failsafe-go"
 
 func NewExecutionAttempt[R any](result *failsafe.ExecutionResult[R], exec *failsafe.Execution[R]) failsafe.ExecutionAttempt[R] {
 	return failsafe.ExecutionAttempt[R]{

--- a/internal/execution.go
+++ b/internal/execution.go
@@ -1,8 +1,6 @@
 package internal
 
-import (
-	"failsafe"
-)
+import failsafe "github.com/failsafe-go/failsafe-go"
 
 func NewExecutionAttempt[R any](result *failsafe.ExecutionResult[R], exec *failsafe.Execution[R]) failsafe.ExecutionAttempt[R] {
 	return failsafe.ExecutionAttempt[R]{

--- a/internal/policytesting/executor.go
+++ b/internal/policytesting/executor.go
@@ -4,12 +4,12 @@ package policytesting
 import (
 	"fmt"
 
-	"failsafe"
-	"failsafe/circuitbreaker"
-	"failsafe/fallback"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
-	"failsafe/timeout"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
+	"github.com/failsafe-go/failsafe-go/timeout"
 )
 
 func WithRetryStats[R any](rp retrypolicy.RetryPolicyBuilder[R], stats *testutil.Stats) retrypolicy.RetryPolicyBuilder[R] {

--- a/internal/testutil/executor.go
+++ b/internal/testutil/executor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
+	failsafe "github.com/failsafe-go/failsafe-go"
 )
 
 type WhenGet[R any] func(execution failsafe.Execution[R]) (R, error)

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -1,8 +1,6 @@
 package testutil
 
-import (
-	"failsafe"
-)
+import "github.com/failsafe-go/failsafe-go"
 
 type InvalidArgumentError struct {
 	Cause error

--- a/ratelimiter/ratelimiter.go
+++ b/ratelimiter/ratelimiter.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"time"
 
-	"failsafe"
-	"failsafe/internal/util"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/util"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // ErrRateLimitExceeded is returned when an execution exceeds a configured rate limit.

--- a/ratelimiter/ratelimiter_test.go
+++ b/ratelimiter/ratelimiter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 var _ RateLimiter[any] = &rateLimiter[any]{}

--- a/ratelimiter/ratelimiterexecutor.go
+++ b/ratelimiter/ratelimiterexecutor.go
@@ -1,9 +1,9 @@
 package ratelimiter
 
 import (
-	"failsafe"
-	"failsafe/internal"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // rateLimiterExecutor is a failsafe.PolicyExecutor that handles failures according to a RateLimiter.

--- a/ratelimiter/ratelimiterstats.go
+++ b/ratelimiter/ratelimiterstats.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"failsafe/internal/util"
+	"github.com/failsafe-go/failsafe-go/internal/util"
 )
 
 type rateLimiterStats interface {

--- a/ratelimiter/ratelimiterstats_test.go
+++ b/ratelimiter/ratelimiterstats_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 var _ rateLimiterStats = &smoothRateLimiterStats[any]{}

--- a/retrypolicy/retry.go
+++ b/retrypolicy/retry.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"time"
 
-	"failsafe"
-	"failsafe/internal/util"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/util"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 const defaultMaxRetries = 2

--- a/retrypolicy/retryexecutor.go
+++ b/retrypolicy/retryexecutor.go
@@ -4,10 +4,10 @@ import (
 	"math/rand"
 	"time"
 
-	"failsafe"
-	"failsafe/internal"
-	"failsafe/internal/util"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal"
+	"github.com/failsafe-go/failsafe-go/internal/util"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // retryPolicyExecutor is a failsafe.PolicyExecutor that handles failures according to a RetryPolicy.

--- a/retrypolicy/retrypolicy_test.go
+++ b/retrypolicy/retrypolicy_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 var _ RetryPolicy[any] = &retryPolicy[any]{}

--- a/spi/policy.go
+++ b/spi/policy.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"time"
 
-	"failsafe"
-	"failsafe/internal/util"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/util"
 )
 
 // BaseListenablePolicy provides a base for implementing ListenablePolicyBuilder.

--- a/spi/policy_test.go
+++ b/spi/policy_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 func TestIsFailureForNil(t *testing.T) {

--- a/spi/policyexecutor.go
+++ b/spi/policyexecutor.go
@@ -1,8 +1,6 @@
 package spi
 
-import (
-	"failsafe"
-)
+import "github.com/failsafe-go/failsafe-go"
 
 // BasePolicyExecutor provides base implementation of PolicyExecutor.
 type BasePolicyExecutor[R any] struct {

--- a/test/circuitbreaker_test.go
+++ b/test/circuitbreaker_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/circuitbreaker"
-	"failsafe/internal/policytesting"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/failsafe-go/failsafe-go/internal/policytesting"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 func TestShouldRejectInitialExecutionWhenCircuitOpen(t *testing.T) {

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/circuitbreaker"
-	"failsafe/fallback"
-	"failsafe/internal/testutil"
-	"failsafe/internal/util"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/internal/util"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 // Asserts context timeouts are handled as expected.

--- a/test/delayable_circuitbreaker_test.go
+++ b/test/delayable_circuitbreaker_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/circuitbreaker"
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 func TestPanicInCircuitBreakerDelayFunction(t *testing.T) {

--- a/test/delayable_retrypolicy_test.go
+++ b/test/delayable_retrypolicy_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 func TestPanicInRetryPolicyDelayFunction(t *testing.T) {

--- a/test/fallback_test.go
+++ b/test/fallback_test.go
@@ -3,9 +3,9 @@ package test
 import (
 	"testing"
 
-	"failsafe"
-	"failsafe/fallback"
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 // Tests Fallback.WithResult

--- a/test/listeners_test.go
+++ b/test/listeners_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/circuitbreaker"
-	"failsafe/fallback"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 // Asserts that listeners are called the expected number of times for a successful completion.

--- a/test/nested_circuitbreaker_test.go
+++ b/test/nested_circuitbreaker_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/circuitbreaker"
-	"failsafe/internal/testutil"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
 )
 
 // Tests that multiple circuit breakers handle failures as expected, regardless of order.

--- a/test/nested_retrypolicy_test.go
+++ b/test/nested_retrypolicy_test.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/fallback"
-	"failsafe/internal/policytesting"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/policytesting"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 /*

--- a/test/policy_composition_test.go
+++ b/test/policy_composition_test.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/circuitbreaker"
-	"failsafe/fallback"
-	"failsafe/internal/policytesting"
-	"failsafe/internal/testutil"
-	"failsafe/ratelimiter"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/policytesting"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/ratelimiter"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 // RetryPolicy -> CircuitBreaker

--- a/test/ratelimiter_test.go
+++ b/test/ratelimiter_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/internal/testutil"
-	"failsafe/ratelimiter"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/ratelimiter"
 )
 
 func TestReservePermit(t *testing.T) {

--- a/test/retrypolicy_test.go
+++ b/test/retrypolicy_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/internal/policytesting"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal/policytesting"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
 )
 
 // Tests a simple execution that retries.

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"failsafe"
-	"failsafe/fallback"
-	"failsafe/internal/policytesting"
-	"failsafe/internal/testutil"
-	"failsafe/retrypolicy"
-	"failsafe/timeout"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/fallback"
+	"github.com/failsafe-go/failsafe-go/internal/policytesting"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+	"github.com/failsafe-go/failsafe-go/retrypolicy"
+	"github.com/failsafe-go/failsafe-go/timeout"
 )
 
 // Tests a simple execution that does not timeout.

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"time"
 
-	"failsafe"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // ErrTimeoutExceeded is returned when an execution exceeds a configured timeout.

--- a/timeout/timeoutexecutor.go
+++ b/timeout/timeoutexecutor.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"failsafe"
-	"failsafe/internal"
-	"failsafe/spi"
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/internal"
+	"github.com/failsafe-go/failsafe-go/spi"
 )
 
 // timeoutExecutor is a failsafe.PolicyExecutor that handles failures according to a Timeout.


### PR DESCRIPTION
Changes the module name in go.mod to `github.com/failsafe-go/failsafe-go` and updates references to it. I found this to be needed to make use of the library locally.