### PR TITLE
Implement String() method for circuitbreaker.State

### DIFF
--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -2,7 +2,6 @@ package circuitbreaker
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -25,7 +24,7 @@ func (s State) String() string {
 	case HalfOpenState:
 		return "half-open"
 	default:
-		panic(fmt.Sprintf("invalid state %d", s))
+		return "unknown"
 	}
 }
 

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -2,6 +2,7 @@ package circuitbreaker
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -14,6 +15,19 @@ var ErrCircuitBreakerOpen = errors.New("circuit breaker open")
 
 // State of a CircuitBreaker.
 type State int
+
+func (s State) String() string {
+	switch s {
+	case ClosedState:
+		return "closed"
+	case OpenState:
+		return "open"
+	case HalfOpenState:
+		return "half-open"
+	default:
+		panic(fmt.Sprintf("invalid state %d", s))
+	}
+}
 
 const (
 	// ClosedState indicates the circuit is closed and fully functional, allowing executions to occur.


### PR DESCRIPTION
Adds a method for a text representation of circuit breaker state which can be useful for including the state in metrics or logging.