### PR TITLE
retrypolicy: fix '-1' logic for WithMaxAttempts => maxRetries

### DIFF
--- a/retrypolicy/retry.go
+++ b/retrypolicy/retry.go
@@ -238,7 +238,11 @@ func (c *retryPolicyConfig[R]) ReturnLastFailure() RetryPolicyBuilder[R] {
 }
 
 func (c *retryPolicyConfig[R]) WithMaxAttempts(maxAttempts int) RetryPolicyBuilder[R] {
-	c.maxRetries = maxAttempts - 1
+	if maxAttempts == -1 {
+		c.maxRetries = -1
+	} else {
+		c.maxRetries = maxAttempts - 1
+	}
 	return c
 }
 


### PR DESCRIPTION
Before, setting `WithMaxAttempts(-1)` led to `maxRetries = -2`, and this check would *always* trigger:
https://github.com/failsafe-go/failsafe-go/blob/d6a1efdc21330e67a06e69ad1ffd21507a729ffe/retrypolicy/retryexecutor.go#L82

As a result, no retry attempts would be made.