### PR TITLE
Add cache policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Upcoming Release
 
+## 0.6.2
+
+## Improvements
+
+- New CachePolicy.
+
 ## 0.6.1
 
 ## Improvements

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Failsafe-go is a library for building fault tolerant Go applications. It works by wrapping executable logic with one or more resilience policies, which can be combined and composed as needed. 
 
-Policies include [Retry](https://failsafe-go.dev/retry/), [CircuitBreaker](https://failsafe-go.dev/circuit-breaker/), [RateLimiter](https://failsafe-go.dev/rate-limiter/), [Timeout](https://failsafe-go.dev/timeout/), [Fallback](https://failsafe-go.dev/fallback/), [Hedge](https://failsafe-go.dev/hedge/), and [Bulkhead](https://failsafe-go.dev/bulkhead/).
+Policies include [Retry](https://failsafe-go.dev/retry), [CircuitBreaker](https://failsafe-go.dev/circuit-breaker), [RateLimiter](https://failsafe-go.dev/rate-limiter), [Timeout](https://failsafe-go.dev/timeout), [Fallback](https://failsafe-go.dev/fallback), [Hedge](https://failsafe-go.dev/hedge/), [Bulkhead](https://failsafe-go.dev/bulkhead), and [Cache](https://failsafe-go.dev/cache).
 
 ## Usage
 

--- a/cachepolicy/cache.go
+++ b/cachepolicy/cache.go
@@ -1,0 +1,121 @@
+package cachepolicy
+
+import (
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/policy"
+)
+
+type key int
+
+// CacheKey is a key to use with a Context that stores the cache key.
+const CacheKey key = 0
+
+// Cache is a simple interface for cached values that can be adapted to different cache backends.
+type Cache[R any] interface {
+	// Get gets and returns a cache entry along with a flag indicating if it's present.
+	Get(key string) (R, bool)
+
+	// Set stores a value for the key in the cache.
+	Set(key string, value R)
+}
+
+// CachePolicy is a read through cachePolicy that returns a cached result for the CacheKey in the context provided with the execution, if it exists.
+//
+// This type is concurrency safe.
+type CachePolicy[R any] interface {
+	failsafe.Policy[R]
+}
+
+// CachePolicyBuilder builds CachePolicy instances. In order for the cache policy to be used, a key must be provided via
+// WithKey, or via a Context when the execution is performed using a value stored under the CacheKey in the Context. A
+// cache key stored in a Context under the CacheKey takes precedence over a cache key configured via WithKey.
+//
+// This type is not concurrency safe.
+type CachePolicyBuilder[R any] interface {
+	// WithKey builds caches that store successful execution results in a cache with the key.
+	WithKey(key string) CachePolicyBuilder[R]
+
+	// CacheIf specifies that a value result should only be cached if it satisfies the predicate. By default, any non-error
+	// results will be cached.
+	CacheIf(predicate func(R, error) bool) CachePolicyBuilder[R]
+
+	// OnCacheHit registers the listener to be called when the cachePolicy entry is hit during an execution.
+	OnCacheHit(listener func(event failsafe.ExecutionDoneEvent[R])) CachePolicyBuilder[R]
+
+	// OnCacheMiss registers the listener to be called when the cachePolicy entry is missed during an execution.
+	OnCacheMiss(listener func(event failsafe.ExecutionEvent[R])) CachePolicyBuilder[R]
+
+	// OnResultCached registers the listener to be called when a result is cached.
+	OnResultCached(listener func(event failsafe.ExecutionEvent[R])) CachePolicyBuilder[R]
+
+	// Build returns a new CachePolicy using the builder's configuration.
+	Build() CachePolicy[R]
+}
+
+type cachePolicyConfig[R any] struct {
+	cache           Cache[R]
+	key             string
+	cacheConditions []func(result R, err error) bool
+	onHit           func(event failsafe.ExecutionDoneEvent[R])
+	onMiss          func(failsafe.ExecutionEvent[R])
+	onCache         func(failsafe.ExecutionEvent[R])
+}
+
+var _ CachePolicyBuilder[any] = &cachePolicyConfig[any]{}
+
+type cachePolicy[R any] struct {
+	config *cachePolicyConfig[R]
+}
+
+// With returns a new CachePolicy. The resulting CachePolicy will only be used with executions that provide a Context
+// containing a CacheKey value.
+func With[R any](cache Cache[R]) CachePolicy[R] {
+	return Builder[R](cache).Build()
+}
+
+// Builder returns a CachePolicyBuilder.
+func Builder[R any](cache Cache[R]) CachePolicyBuilder[R] {
+	return &cachePolicyConfig[R]{
+		cache: cache,
+	}
+}
+
+func (c *cachePolicyConfig[R]) CacheIf(predicate func(R, error) bool) CachePolicyBuilder[R] {
+	c.cacheConditions = append(c.cacheConditions, predicate)
+	return c
+}
+
+func (c *cachePolicyConfig[R]) WithKey(key string) CachePolicyBuilder[R] {
+	c.key = key
+	return c
+}
+
+func (c *cachePolicyConfig[R]) OnCacheHit(listener func(event failsafe.ExecutionDoneEvent[R])) CachePolicyBuilder[R] {
+	c.onHit = listener
+	return c
+}
+
+func (c *cachePolicyConfig[R]) OnCacheMiss(listener func(event failsafe.ExecutionEvent[R])) CachePolicyBuilder[R] {
+	c.onMiss = listener
+	return c
+}
+
+func (c *cachePolicyConfig[R]) OnResultCached(listener func(event failsafe.ExecutionEvent[R])) CachePolicyBuilder[R] {
+	c.onCache = listener
+	return c
+}
+
+func (c *cachePolicyConfig[R]) Build() CachePolicy[R] {
+	return &cachePolicy[R]{
+		config: c, // TODO copy base fields
+	}
+}
+
+func (c *cachePolicy[R]) ToExecutor(_ R) any {
+	ce := &cacheExecutor[R]{
+		BaseExecutor: &policy.BaseExecutor[R]{},
+		cachePolicy:  c,
+	}
+	ce.Executor = ce
+	return ce
+}

--- a/cachepolicy/cacheexecutor.go
+++ b/cachepolicy/cacheexecutor.go
@@ -1,0 +1,70 @@
+package cachepolicy
+
+import (
+	"context"
+
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/common"
+	"github.com/failsafe-go/failsafe-go/internal/util"
+	"github.com/failsafe-go/failsafe-go/policy"
+)
+
+// cacheExecutor is a policy.Executor that handles failures according to a CachePolicy.
+type cacheExecutor[R any] struct {
+	*policy.BaseExecutor[R]
+	*cachePolicy[R]
+}
+
+var _ policy.Executor[any] = &cacheExecutor[any]{}
+
+func (e *cacheExecutor[R]) PreExecute(exec policy.ExecutionInternal[R]) *common.PolicyResult[R] {
+	execInternal := exec.(policy.ExecutionInternal[R])
+	if cacheKey := e.getCacheKey(exec.Context()); cacheKey != "" {
+		if cacheResult, found := e.config.cache.Get(cacheKey); found {
+			if e.config.onHit != nil {
+				e.config.onHit(failsafe.ExecutionDoneEvent[R]{
+					ExecutionStats: execInternal,
+					Result:         cacheResult,
+				})
+			}
+			return &common.PolicyResult[R]{
+				Result:     cacheResult,
+				Done:       true,
+				Success:    true,
+				SuccessAll: true,
+			}
+		}
+	}
+	if e.config.onMiss != nil {
+		e.config.onMiss(failsafe.ExecutionEvent[R]{
+			ExecutionAttempt: execInternal,
+		})
+	}
+	return nil
+}
+
+func (e *cacheExecutor[R]) PostExecute(exec policy.ExecutionInternal[R], er *common.PolicyResult[R]) *common.PolicyResult[R] {
+	shouldCache := (len(e.config.cacheConditions) == 0 && er.Error == nil) ||
+		util.AppliesToAny(e.config.cacheConditions, er.Result, er.Error)
+
+	if shouldCache {
+		if cacheKey := e.getCacheKey(exec.Context()); cacheKey != "" {
+			e.config.cache.Set(cacheKey, er.Result)
+			if e.config.onCache != nil {
+				e.config.onCache(failsafe.ExecutionEvent[R]{
+					ExecutionAttempt: exec.CopyWithResult(er),
+				})
+			}
+		}
+	}
+	return er
+}
+
+func (e *cacheExecutor[R]) getCacheKey(ctx context.Context) string {
+	if untypedKey := ctx.Value(CacheKey); untypedKey != nil {
+		if typedKey, ok := untypedKey.(string); ok {
+			return typedKey
+		}
+	}
+	return e.config.key
+}

--- a/cachepolicy/doc.go
+++ b/cachepolicy/doc.go
@@ -1,0 +1,2 @@
+// Package cachepolicy provides a CachePolicy policy.
+package cachepolicy

--- a/internal/policytesting/cache.go
+++ b/internal/policytesting/cache.go
@@ -1,0 +1,25 @@
+package policytesting
+
+import (
+	"github.com/failsafe-go/failsafe-go/cachepolicy"
+)
+
+type TestCache[R any] struct {
+	Cache map[string]R
+}
+
+func (c *TestCache[R]) Get(key string) (R, bool) {
+	result, found := c.Cache[key]
+	return result, found
+}
+
+func (c *TestCache[R]) Set(key string, value R) {
+	c.Cache[key] = value
+}
+
+func NewCache[R any]() (map[string]R, cachepolicy.Cache[R]) {
+	cache := make(map[string]R)
+	return cache, &TestCache[R]{
+		Cache: cache,
+	}
+}

--- a/internal/testutil/executor.go
+++ b/internal/testutil/executor.go
@@ -25,11 +25,15 @@ func TestRunFailure[R any](t *testing.T, given Given, executor failsafe.Executor
 }
 
 func TestGetSuccess[R any](t *testing.T, given Given, executor failsafe.Executor[R], when WhenGet[R], expectedAttempts int, expectedExecutions int, expectedResult R, then ...func()) {
-	testGet(t, given, executor, when, expectedAttempts, expectedExecutions, expectedResult, nil, then...)
+	testGet(t, given, executor, when, expectedAttempts, expectedExecutions, expectedResult, nil, true, then...)
+}
+
+func TestGetSuccessError[R any](t *testing.T, given Given, executor failsafe.Executor[R], when WhenGet[R], expectedAttempts int, expectedExecutions int, expectedError error, then ...func()) {
+	testGet(t, given, executor, when, expectedAttempts, expectedExecutions, *(new(R)), expectedError, true, then...)
 }
 
 func TestGetFailure[R any](t *testing.T, given Given, executor failsafe.Executor[R], when WhenGet[R], expectedAttempts int, expectedExecutions int, expectedError error, then ...func()) {
-	testGet(t, given, executor, when, expectedAttempts, expectedExecutions, *(new(R)), expectedError, then...)
+	testGet(t, given, executor, when, expectedAttempts, expectedExecutions, *(new(R)), expectedError, false, then...)
 }
 
 func testRun[R any](t *testing.T, given Given, executor failsafe.Executor[R], when WhenRun[R], expectedAttempts int, expectedExecutions int, expectedError error, then ...func()) {
@@ -45,8 +49,8 @@ func testRun[R any](t *testing.T, given Given, executor failsafe.Executor[R], wh
 	assertResult(executorFn().RunWithExecutionAsync(when).Get())
 }
 
-func testGet[R any](t *testing.T, given Given, executor failsafe.Executor[R], when WhenGet[R], expectedAttempts int, expectedExecutions int, expectedResult R, expectedError error, then ...func()) {
-	executorFn, assertResult := PrepareTest(t, given, executor, expectedAttempts, expectedExecutions, expectedResult, &expectedError, expectedError == nil, then...)
+func testGet[R any](t *testing.T, given Given, executor failsafe.Executor[R], when WhenGet[R], expectedAttempts int, expectedExecutions int, expectedResult R, expectedError error, expectedSuccess bool, then ...func()) {
+	executorFn, assertResult := PrepareTest(t, given, executor, expectedAttempts, expectedExecutions, expectedResult, &expectedError, expectedSuccess, then...)
 
 	// Run sync
 	fmt.Println("Testing sync")

--- a/test/bulkhead_test.go
+++ b/test/bulkhead_test.go
@@ -37,7 +37,7 @@ func TestBulkheadPermitAcquiredAfterWait(t *testing.T) {
 func TestBulkheadFull(t *testing.T) {
 	// Given
 	stats := &policytesting.Stats{}
-	bh := policytesting.BulkheadStatsAndLogs(bulkhead.Builder[any](2), stats, true).Build()
+	bh := policytesting.WithBulkheadStatsAndLogs(bulkhead.Builder[any](2), stats, true).Build()
 	bh.TryAcquirePermit()
 	bh.TryAcquirePermit() // bulkhead should be full
 

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -1,0 +1,172 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/cachepolicy"
+	"github.com/failsafe-go/failsafe-go/internal/policytesting"
+	"github.com/failsafe-go/failsafe-go/internal/testutil"
+)
+
+// Tests adding and getting an item from the cache. Uses different cache key scenarios, including global, per context,
+// and no cache key.
+func TestCache(t *testing.T) {
+	// Given
+	cache, failsafeCache := policytesting.NewCache[string]()
+	stats := &policytesting.Stats{}
+
+	// When / Then
+	tests := []struct {
+		name               string
+		executor           failsafe.Executor[string]
+		expectedExecutions int
+		expectedResult     string
+		expectedCaches     int
+		expectedHits       int
+		expectedMisses     int
+	}{
+		{
+			name: "with global key",
+			executor: failsafe.NewExecutor[string](
+				policytesting.WithCacheStats(cachepolicy.Builder[string](failsafeCache).
+					WithKey("foo"), stats).
+					Build(),
+			),
+			expectedExecutions: 0,
+			expectedResult:     "bar",
+			expectedCaches:     1,
+			expectedHits:       1,
+			expectedMisses:     0,
+		},
+		{
+			name: "with context key",
+			executor: failsafe.NewExecutor[string](
+				policytesting.WithCacheStats(cachepolicy.Builder[string](failsafeCache), stats).Build()).
+				WithContext(context.WithValue(context.Background(), cachepolicy.CacheKey, "foo2")),
+			expectedExecutions: 0,
+			expectedResult:     "bar",
+			expectedCaches:     1,
+			expectedHits:       1,
+			expectedMisses:     0,
+		},
+		{
+			name: "with no key",
+			executor: failsafe.NewExecutor[string](
+				policytesting.WithCacheStats(cachepolicy.Builder[string](failsafeCache), stats).Build(),
+			),
+			expectedExecutions: 1,
+			expectedResult:     "missing",
+			expectedCaches:     0,
+			expectedHits:       0,
+			expectedMisses:     1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setup := func() context.Context {
+				stats.Reset()
+				clear(cache)
+				return nil
+			}
+
+			// Add item to cache
+			testutil.TestGetSuccess(t, setup, tc.executor,
+				func(execution failsafe.Execution[string]) (string, error) {
+					return "bar", nil
+				},
+				1, 1, "bar", func() {
+					assert.Equal(t, tc.expectedCaches, stats.Caches())
+					assert.Equal(t, 0, stats.CacheHits())
+					assert.Equal(t, 1, stats.CacheMisses())
+				})
+
+			// Get item from cache
+			testutil.TestGetSuccess(t, policytesting.SetupFn(stats), tc.executor,
+				func(execution failsafe.Execution[string]) (string, error) {
+					return "missing", nil
+				},
+				1, tc.expectedExecutions, tc.expectedResult, func() {
+					assert.Equal(t, 0, stats.Caches())
+					assert.Equal(t, tc.expectedHits, stats.CacheHits())
+					assert.Equal(t, tc.expectedMisses, stats.CacheMisses())
+				})
+		})
+	}
+}
+
+func TestConditionalCache(t *testing.T) {
+	// Given
+	cache, failsafeCache := policytesting.NewCache[string]()
+	stats := &policytesting.Stats{}
+	barPredicate := func(s string, err error) bool { return s == "bar" }
+
+	// When / Then
+	tests := []struct {
+		name           string
+		cpb            cachepolicy.CachePolicyBuilder[string]
+		result         string
+		expectedCaches int
+	}{
+		{
+			name: "with matching condition",
+			cpb: policytesting.WithCacheStats(cachepolicy.Builder[string](failsafeCache), stats).WithKey("foo").
+				CacheIf(barPredicate),
+			result:         "bar",
+			expectedCaches: 1,
+		},
+		{
+			name: "with non-matching condition",
+			cpb: policytesting.WithCacheStats(cachepolicy.Builder[string](failsafeCache), stats).WithKey("foo").
+				CacheIf(barPredicate),
+			result:         "baz",
+			expectedCaches: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setup := func() context.Context {
+				stats.Reset()
+				clear(cache)
+				return nil
+			}
+
+			// When / Then
+			testutil.TestGetSuccess(t, setup, failsafe.NewExecutor[string](tc.cpb.Build()),
+				func(execution failsafe.Execution[string]) (string, error) {
+					return tc.result, nil
+				},
+				1, 1, tc.result, func() {
+					assert.Equal(t, tc.expectedCaches, stats.Caches())
+					assert.Equal(t, 0, stats.CacheHits())
+					assert.Equal(t, 1, stats.CacheMisses())
+				})
+		})
+	}
+}
+
+// Tests that a result is not cached when an error occurs.
+func TestDoNotCacheOnError(t *testing.T) {
+	// Given
+	_, failsafeCache := policytesting.NewCache[string]()
+	stats := &policytesting.Stats{}
+	cp := policytesting.WithCacheStats(cachepolicy.Builder[string](failsafeCache), stats).
+		WithKey("foo").
+		Build()
+
+	// When / Then
+	testutil.TestGetSuccessError(t, policytesting.SetupFn(stats), failsafe.NewExecutor[string](cp),
+		func(execution failsafe.Execution[string]) (string, error) {
+			return "", testutil.ErrInvalidState
+		},
+		1, 1, testutil.ErrInvalidState, func() {
+			assert.Equal(t, 0, stats.Caches())
+			assert.Equal(t, 0, stats.CacheHits())
+			assert.Equal(t, 1, stats.CacheMisses())
+		})
+}


### PR DESCRIPTION
This PR adds a new cache policy. 

In order to support different cache implementations, Failsafe-go defines a simple `cachepolicy.Cache` interface that adapts to different implementations. Example: a simple Ristretto implementation:

```go
type ristrettoCache[R any] struct {
	cache *ristretto.Cache
}

func (r *ristrettoCache[R]) Get(key string) (R, bool) {
	if result, found := r.cache.Get(key); found {
		if typedResult, ok := result.(R); ok {
			return typedResult, true
		}
	}
	return *(new(R)), false
}

func (r *ristrettoCache[R]) Set(key string, value R) {
	r.cache.Set(key, value, 0)
}
```

I may ship some of these out of the box for common cache implementations.

To use a `cachepolicy.Cache` in a Failsafe-go execution, you create a `CachePolicy` for some key:

```go
cachePolicy := cachepolicy.Builder[Connection](cache).WithKey("connection").Build()
```

Then you can use the policy as usual, along with any other policies you wish:

```go
connection, err := executor.Run(Connect, cachePolicy, retryPolicy, circuitBreaker)
```

Successful execution results will be cached in the `cache` under the "connection" key. 

If you want to provide a different cache key for each execution, or you just don't want to embed a cache key in the `CachePolicy` itself, you can provide one via a context with the execution:

```go
executor := failsafe.NewExecutor[Connection](cachePolicy)
ctx := context.WithValue(context.Background(), cachepolicy.CacheKey, "foo")
connection, err := executor.WithContext(ctx).Run(Connect, cachePolicy)
```

A `CachePolicy` supports custom [failure handling](https://failsafe-go.dev/policies/#failure-handling) and [event listeners](https://failsafe-go.dev/event-listeners/#policy-listeners).

Fixes #38 