### PR TITLE
Fix missing implementation for budget.New().WithMinConcurrency

### DIFF
--- a/budget/budget.go
+++ b/budget/budget.go
@@ -113,7 +113,7 @@ type budget struct {
 }
 
 func (b *budget) TryAcquireRetryPermit() bool {
-	if b.RetryRate() > b.maxRate {
+	if b.RetryRate() > b.maxRate && b.retries.Load() >= int32(b.minConcurrency) {
 		return false
 	}
 
@@ -123,7 +123,7 @@ func (b *budget) TryAcquireRetryPermit() bool {
 }
 
 func (b *budget) TryAcquireHedgePermit() bool {
-	if b.HedgeRate() > b.maxRate {
+	if b.HedgeRate() > b.maxRate && b.hedges.Load() >= int32(b.minConcurrency) {
 		return false
 	}
 

--- a/test/budget_test.go
+++ b/test/budget_test.go
@@ -120,4 +120,34 @@ func TestBudget(t *testing.T) {
 				assert.Equal(t, 1, stats.BudgetExceededs())
 			})
 	})
+
+	// This test verifies that minConcurrency allows retries to proceed even when the retry rate exceeds maxRate.
+	t.Run("when min concurrency allows retries to proceed", func(t *testing.T) {
+		// Given a budget that should allow 3 concurrent retries.
+		bb := budget.NewBuilder().
+			WithMaxRate(.001).
+			WithMinConcurrency(3).
+			Build().(internal.Budget)
+
+		// When we attempt to acquire 3 retry permits, then attempt a 4th which should be rejected.
+		assert.True(t, bb.TryAcquireRetryPermit())
+		assert.True(t, bb.TryAcquireRetryPermit())
+		assert.True(t, bb.TryAcquireRetryPermit())
+		assert.False(t, bb.TryAcquireRetryPermit())
+	})
+
+	// This test verifies that minConcurrency allows hedges to proceed even when the hedge rate exceeds maxRate.
+	t.Run("when min concurrency allows hedges to proceed", func(t *testing.T) {
+		// Given a budget that should allow 3 concurrent hedges.
+		bb := budget.NewBuilder().
+			WithMaxRate(.001).
+			WithMinConcurrency(3).
+			Build().(internal.Budget)
+
+		// When we attempt to acquire 3 hedge permits, then attempt a 4th which should be rejected.
+		assert.True(t, bb.TryAcquireHedgePermit())
+		assert.True(t, bb.TryAcquireHedgePermit())
+		assert.True(t, bb.TryAcquireHedgePermit())
+		assert.False(t, bb.TryAcquireHedgePermit())
+	})
 }


### PR DESCRIPTION
When I was using the lib I noticed that `WithMinConcurrency` wasn't respected.

There is a missing part of the implementation, this PR fixes that.

Code to reproduce error (also added as a test):
```
		bb := budget.NewBuilder().
			WithMaxRate(.001).
			WithMinConcurrency(3).
			Build().(internal.Budget)

		assert.True(t, bb.TryAcquireRetryPermit())
		assert.True(t, bb.TryAcquireRetryPermit()) // returns false, but should return true
```