### PR TITLE
Add jitter and randomized delay to the circuit breaker open state

### DIFF
--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -3,6 +3,7 @@ package circuitbreaker
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -46,9 +47,10 @@ CircuitBreaker is a policy that temporarily blocks execution when a configured n
 breakers have three states: closed, open, and half-open. When a circuit breaker is in the ClosedState (default),
 executions are allowed. If a configurable number of failures occur, optionally over some time period, the circuit
 breaker transitions to OpenState. In the OpenState a circuit breaker will fail executions with ErrOpen.
-After a configurable delay, the circuit breaker will transition to HalfOpenState. In the HalfOpenState a configurable
-number of trial executions will be allowed, after which the circuit breaker will transition to either ClosedState or
-OpenState depending on how many were successful.
+After a configurable delay, the circuit breaker will transition to HalfOpenState. The delay can be fixed, computed via a
+DelayFunc, or randomized, and can be jittered to desynchronize the half-open probes of breakers that opened together. In
+the HalfOpenState a configurable number of trial executions will be allowed, after which the circuit breaker will
+transition to either ClosedState or OpenState depending on how many were successful.
 
 A circuit breaker can be count based or time based:
 
@@ -299,11 +301,7 @@ func (cb *circuitBreaker[R]) transitionTo(newState State, exec failsafe.Executio
 		case ClosedState:
 			cb.state = newClosedState(cb)
 		case OpenState:
-			delay := cb.ComputeDelay(exec)
-			if delay == -1 {
-				delay = cb.Delay
-			}
-			cb.state = newOpenState(cb, cb.state, delay)
+			cb.state = newOpenState(cb, cb.state, cb.getDelay(exec))
 		case HalfOpenState:
 			cb.state = newHalfOpenState(cb)
 		}
@@ -359,6 +357,28 @@ func (m *eventMetrics) SuccessRate() float64 {
 // Requires external locking.
 func (cb *circuitBreaker[R]) tryAcquirePermit() bool {
 	return cb.state.tryAcquirePermit()
+}
+
+// getDelay returns the delay to wait in the OpenState before transitioning to HalfOpenState. It resolves the base
+// delay from the DelayFunc, else a configured random delay range, else the fixed delay, and then applies any configured
+// jitter. Jitter desynchronizes the half-open probes of many breakers that opened at the same time.
+func (cb *circuitBreaker[R]) getDelay(exec failsafe.Execution[R]) time.Duration {
+	var delay time.Duration
+	if computed := cb.ComputeDelay(exec); computed != -1 {
+		delay = computed
+	} else if cb.delayMin != 0 && cb.delayMax != 0 {
+		delay = time.Duration(util.RandomDelayInRange(cb.delayMin.Nanoseconds(), cb.delayMax.Nanoseconds(), rand.Float64()))
+	} else {
+		delay = cb.Delay
+	}
+	if delay != 0 {
+		if cb.jitter != 0 {
+			delay = util.RandomDelay(delay, cb.jitter, rand.Float64())
+		} else if cb.jitterFactor != 0 {
+			delay = util.RandomDelayFactor(delay, cb.jitterFactor, rand.Float64())
+		}
+	}
+	return delay
 }
 
 // Opens the circuit breaker and considers the execution when computing the delay before the circuit breaker

--- a/circuitbreaker/circuitbreakerbuilder.go
+++ b/circuitbreaker/circuitbreakerbuilder.go
@@ -73,6 +73,23 @@ type Builder[R any] interface {
 	// WithDelayFunc configures a function that provides the delay to wait in OpenState before transitioning to HalfOpenState.
 	WithDelayFunc(delayFunc failsafe.DelayFunc[R]) Builder[R]
 
+	// WithRandomDelay configures a random delay to wait in OpenState before transitioning to HalfOpenState, chosen
+	// randomly between the delayMin and delayMax. Replaces any previously configured fixed delay.
+	WithRandomDelay(delayMin time.Duration, delayMax time.Duration) Builder[R]
+
+	// WithJitter configures the jitter to randomly vary the OpenState delay by. For each delay, a random portion of the
+	// jitter will be added or subtracted to the delay. For example: a jitter of 100 milliseconds will randomly add
+	// between -100 and 100 milliseconds to each delay. Jittering the delay prevents multiple circuit breakers that open
+	// at the same time from transitioning to HalfOpenState in lockstep and re-probing an unhealthy dependency together.
+	// Replaces any previously configured jitter factor.
+	WithJitter(jitter time.Duration) Builder[R]
+
+	// WithJitterFactor configures the jitterFactor to randomly vary the OpenState delay by. For each delay, a random
+	// portion of the delay multiplied by the jitterFactor will be added or subtracted to the delay. For example: a delay
+	// of 100 milliseconds and a jitterFactor of .25 will result in a random delay between 75 and 125 milliseconds.
+	// Replaces any previously configured jitter duration.
+	WithJitterFactor(jitterFactor float64) Builder[R]
+
 	// WithSuccessThreshold configures count based success thresholding by setting the number of consecutive successful
 	// executions that must occur when in a HalfOpenState in order to close the circuit, else the circuit is re-opened when a
 	// failure occurs.
@@ -90,7 +107,14 @@ type Builder[R any] interface {
 type config[R any] struct {
 	policy.BaseFailurePolicy[R]
 	policy.BaseDelayablePolicy[R]
-	clock                util.Clock
+	clock util.Clock
+
+	// Delay config that augments BaseDelayablePolicy.Delay
+	delayMin     time.Duration
+	delayMax     time.Duration
+	jitter       time.Duration
+	jitterFactor float64
+
 	stateChangedListener func(StateChangedEvent)
 	openListener         func(StateChangedEvent)
 	halfOpenListener     func(StateChangedEvent)
@@ -203,6 +227,25 @@ func (c *config[R]) WithDelay(delay time.Duration) Builder[R] {
 
 func (c *config[R]) WithDelayFunc(delayFunc failsafe.DelayFunc[R]) Builder[R] {
 	c.BaseDelayablePolicy.WithDelayFunc(delayFunc)
+	return c
+}
+
+func (c *config[R]) WithRandomDelay(delayMin time.Duration, delayMax time.Duration) Builder[R] {
+	c.delayMin = delayMin
+	c.delayMax = delayMax
+
+	// Clear fixed delay
+	c.Delay = 0
+	return c
+}
+
+func (c *config[R]) WithJitter(jitter time.Duration) Builder[R] {
+	c.jitter = jitter
+	return c
+}
+
+func (c *config[R]) WithJitterFactor(jitterFactor float64) Builder[R] {
+	c.jitterFactor = jitterFactor
 	return c
 }
 

--- a/circuitbreaker/circuitstates.go
+++ b/circuitbreaker/circuitstates.go
@@ -73,7 +73,7 @@ func (s *closedState[R]) checkThresholdAndReleasePermit(exec failsafe.Execution[
 type openState[R any] struct {
 	breaker *circuitBreaker[R]
 	util.ExecutionStats
-	startTime int64
+	startTime time.Time
 	delay     time.Duration
 }
 
@@ -81,7 +81,7 @@ func newOpenState[R any](breaker *circuitBreaker[R], previousState circuitState[
 	return &openState[R]{
 		breaker:        breaker,
 		ExecutionStats: previousState,
-		startTime:      breaker.clock.Now().UnixNano(),
+		startTime:      breaker.clock.Now(),
 		delay:          delay,
 	}
 }
@@ -91,12 +91,11 @@ func (s *openState[R]) state() State {
 }
 
 func (s *openState[R]) remainingDelay() time.Duration {
-	elapsedTime := s.breaker.clock.Now().UnixNano() - s.startTime
-	return max(0, s.delay-time.Duration(elapsedTime))
+	return max(0, s.delay-s.breaker.clock.Now().Sub(s.startTime))
 }
 
 func (s *openState[R]) tryAcquirePermit() bool {
-	if s.breaker.clock.Now().UnixNano()-s.startTime >= s.delay.Nanoseconds() {
+	if s.breaker.clock.Now().Sub(s.startTime) >= s.delay {
 		s.breaker.halfOpen()
 		return s.breaker.tryAcquirePermit()
 	}

--- a/circuitbreaker/openstate_test.go
+++ b/circuitbreaker/openstate_test.go
@@ -13,15 +13,17 @@ import (
 var _ circuitState[any] = &openState[any]{}
 
 func TestTryAcquirePermit(t *testing.T) {
+	clock := testutil.NewTestClock(0)
 	breaker := NewBuilder[any]().WithDelayFunc(func(exec failsafe.ExecutionAttempt[any]) time.Duration {
 		return 100 * time.Millisecond
 	}).Build().(*circuitBreaker[any])
+	breaker.clock = clock
 	breaker.open(testutil.TestExecution[any]{})
 	assert.True(t, breaker.IsOpen())
 	assert.False(t, breaker.TryAcquirePermit())
 
 	// When
-	time.Sleep(110 * time.Millisecond)
+	clock.SetTime(110)
 
 	// Then
 	assert.True(t, breaker.TryAcquirePermit())
@@ -29,9 +31,11 @@ func TestTryAcquirePermit(t *testing.T) {
 }
 
 func TestRemainingDelay(t *testing.T) {
+	clock := testutil.NewTestClock(0)
 	breaker := NewBuilder[any]().WithDelayFunc(func(exec failsafe.ExecutionAttempt[any]) time.Duration {
 		return 1 * time.Second
 	}).Build().(*circuitBreaker[any])
+	breaker.clock = clock
 	breaker.open(testutil.TestExecution[any]{})
 
 	// When / Then
@@ -39,22 +43,75 @@ func TestRemainingDelay(t *testing.T) {
 	assert.True(t, remainingDelay > 0)
 	assert.True(t, remainingDelay.Milliseconds() < 1001)
 
-	time.Sleep(110 * time.Millisecond)
+	clock.SetTime(110)
 	remainingDelay = breaker.RemainingDelay()
 	assert.True(t, remainingDelay > 0)
 	assert.True(t, remainingDelay.Milliseconds() < 900)
 }
 
+// Asserts that a configured jitter keeps the OpenState delay within [delay-jitter, delay+jitter]. The delay just after
+// opening equals RemainingDelay since no time has elapsed on the test clock.
+func TestJitteredDelay(t *testing.T) {
+	clock := testutil.NewTestClock(0)
+	for i := 0; i < 100; i++ {
+		breaker := NewBuilder[any]().
+			WithDelay(100 * time.Millisecond).
+			WithJitter(20 * time.Millisecond).
+			Build().(*circuitBreaker[any])
+		breaker.clock = clock
+		breaker.open(testutil.TestExecution[any]{})
+
+		delay := breaker.RemainingDelay()
+		assert.GreaterOrEqual(t, delay, 80*time.Millisecond)
+		assert.LessOrEqual(t, delay, 120*time.Millisecond)
+	}
+}
+
+// Asserts that a configured jitter factor keeps the OpenState delay within [delay*(1-factor), delay*(1+factor)].
+func TestJitterFactorDelay(t *testing.T) {
+	clock := testutil.NewTestClock(0)
+	for i := 0; i < 100; i++ {
+		breaker := NewBuilder[any]().
+			WithDelay(100 * time.Millisecond).
+			WithJitterFactor(.25).
+			Build().(*circuitBreaker[any])
+		breaker.clock = clock
+		breaker.open(testutil.TestExecution[any]{})
+
+		delay := breaker.RemainingDelay()
+		assert.GreaterOrEqual(t, delay, 75*time.Millisecond)
+		assert.LessOrEqual(t, delay, 125*time.Millisecond)
+	}
+}
+
+// Asserts that a configured random delay keeps the OpenState delay within [delayMin, delayMax].
+func TestRandomDelay(t *testing.T) {
+	clock := testutil.NewTestClock(0)
+	for i := 0; i < 100; i++ {
+		breaker := NewBuilder[any]().
+			WithRandomDelay(50*time.Millisecond, 150*time.Millisecond).
+			Build().(*circuitBreaker[any])
+		breaker.clock = clock
+		breaker.open(testutil.TestExecution[any]{})
+
+		delay := breaker.RemainingDelay()
+		assert.GreaterOrEqual(t, delay, 50*time.Millisecond)
+		assert.LessOrEqual(t, delay, 150*time.Millisecond)
+	}
+}
+
 func TestNoRemainingDelay(t *testing.T) {
+	clock := testutil.NewTestClock(0)
 	breaker := NewBuilder[any]().WithDelayFunc(func(exec failsafe.ExecutionAttempt[any]) time.Duration {
 		return 10 * time.Millisecond
 	}).Build().(*circuitBreaker[any])
+	breaker.clock = clock
 	assert.Equal(t, time.Duration(0), breaker.RemainingDelay())
 
 	// When
 	breaker.open(testutil.TestExecution[any]{})
 	assert.True(t, breaker.RemainingDelay() > 0)
-	time.Sleep(50 * time.Millisecond)
+	clock.SetTime(50)
 
 	// Then
 	assert.Equal(t, time.Duration(0), breaker.RemainingDelay())


### PR DESCRIPTION
## What

Adds three opt-in builder options controlling the delay a circuit breaker waits in the open state before transitioning to half-open:

- `WithJitter(duration)`: randomly vary the delay by ±duration
- `WithJitterFactor(factor)`: vary the delay by ±(delay × factor)
- `WithRandomDelay(min, max)`: pick the delay uniformly from [min, max]

These mirror the existing `retrypolicy` options and reuse the same `internal/util.RandomDelay*` helpers, so the vocabulary is consistent across the library. All are opt-in, so the zero-config default is unchanged (a fixed 1-minute delay).

## Why

A circuit breaker's fixed open→half-open delay means that when many breakers guarding the same dependency trip at the same moment, they all half-open and re-probe the recovering dependency in lockstep. That synchronized probe can re-trip the breaker and stall recovery, so the retry-storm dynamic that circuit breakers exist to prevent is reintroduced at the breaker's own cadence.

*Designing Data-Intensive Applications* (2nd ed., Kleppmann & Riccomini), in the sidebar "When an Overloaded System Won't Recover," describes the failure mode and the fix together:

> This causes the rate of requests to increase even further, making the problem worse—a retry storm. Even when the load is reduced again, such a system may remain in an overloaded state until it is rebooted or otherwise reset. This phenomenon is called a metastable failure, and it can cause serious outages in production systems. To avoid retries overloading a service, you can increase and randomize the time between successive retries on the client side (exponential backoff) and temporarily stop sending requests to a service that has returned errors or timed out recently (by using a circuit breaker …).

The book applies "increase and randomize the time between successive retries" to client-side retries; this PR applies the same reasoning to the breaker's own half-open probe timing, so a fleet of breakers desynchronizes its recovery attempts instead of hammering the dependency together.

## Also included

Measure the open-state elapsed time with a monotonic, injectable clock:
`openState` now stores `startTime` as a `time.Time` and compares via `Now().Sub(startTime)` instead of subtracting wall-clock `UnixNano()` values (which discard Go's monotonic reading). This makes the elapsed-time math robust to wall-clock adjustments and lets the open-state tests advance a `testutil.TestClock` instead of calling `time.Sleep`. This makes it so the tests are now deterministic and no longer wall-clock bound.

## Test Changes

- New tests: `TestJitteredDelay`, `TestJitterFactorDelay`, `TestRandomDelay`  assert the computed delay stays within the configured bounds.
- Existing `TestTryAcquirePermit` / `TestRemainingDelay` / `TestNoRemainingDelay` converted off `time.Sleep` to the injected test clock.

## Not included (deliberately)

- Exponential backoff *across successive re-opens*, which is unlike retry's per-attempt backoff; this would need new breaker state (a consecutive-open counter, reset on close); worth a separate PR if you wanted.
- No change to default failure classification: context cancellations still follow the configured `Handle*` conditions rather than being excluded by default, to preserve the existing result-agnostic contract.